### PR TITLE
adds support for broadcast messages for topics

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ To achieve this on On.js you have to register the event, declare the properties 
 
 On.js uses it's own local Redis based queue to order to avoid duplicates if multiple services listen to the same event
 
-On.js provides two options for working with topics. Processing and Dispatching
+On.js provides three options for working with topics. Processing, Dispatching and Broadcasting
 
 Processing means that the task will be added to the queue and processed as soon as the queue determines that it can start processing it.
 
@@ -35,6 +35,16 @@ on
 	.do(callback: function)
 
 ```
+
+Broadcasting means that the task will immediately be executed by ALL the listeners without using redis, the tasks will be "duplicated" across all listeners.
+
+```
+on
+	.broadcastReceived(eventName: string)
+	.do(callback: function)
+
+```
+
 
 #### Processing
 

--- a/lib/on.js
+++ b/lib/on.js
@@ -189,21 +189,18 @@ class On extends EventEmitter {
   }
 
   async _onTopicReceived (event, data) {
-    try {
-      this._eventLog('info', event.eventName, `Creating redis queue with name ${event.eventName}`)
+    this._eventLog('info', event.eventName, `Creating topic queue with name ${event.eventName}`)
 
-      if (event.dispatchAs && event.dispatchAs.length > 0) {
-        this._eventLog('info', event.eventName, `Event is redispatchable`)
-        await this._redispatchToMQ(event, data)
-      }
-      else {
-        this._eventLog('info', event.eventName, `Sending the event to redis as task ${event.eventName}`)
-        this._sendToRedisQueueToProcess(event, data)
-      }
+    if (event.dispatchAs && event.dispatchAs.length > 0) {
+      this._eventLog('info', event.eventName, `Event is redispatchable`)
+      return this._redispatchToMQ(event, data)
     }
-    catch (err) {
-      throw err
+    if (event.asTask) {
+      this._eventLog('info', event.eventName, `Event is going to execute as task`)
+      return this._onTaskReceived(event, data)
     }
+    this._eventLog('info', event.eventName, `Sending the event to redis as task ${event.eventName}`)
+    this._sendToRedisQueueToProcess(event, data)
   }
 
   // Consume queue events from MQ
@@ -315,6 +312,25 @@ class On extends EventEmitter {
 
     this._eventLog('info', eventName, `Registered event ${eventName} and redis queue ${eventName}`)
 
+    return this
+  }
+
+  broadcastReceived (eventName) {
+    this.currentEventNameToRegister = eventName
+    this.currentEventTypeToRegister = 'topic'
+
+    if (this._eventExists(eventName, 'topic')) {
+      this._eventLog('info', eventName, `The event ${eventName} is already registered`)
+      throw new Error(`The event ${eventName} is already registered, possibly as eventReceived`)
+    }
+
+    this.events.push({
+      eventName: eventName,
+      type: 'topic',
+      asTask: true,
+    })
+
+    this._eventLog('info', eventName, `Registered event ${eventName} as broadcast`)
     return this
   }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "onjs",
-  "version": "2.2.1",
+  "version": "2.3.0",
   "description": "On.js is an event library based on RabbitMQ that helps you control events on a microservices arquitecture",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Adds support for broadcasting using topics, by using the new function `broadcastRecieved` this will remove the use of redis/mq for topics, "duplicating" the message to all listeners.