### PR TITLE
Add reconnect support

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Processing means that the task will be added to the queue and processed as soon 
 
 Dispatching means that the task will be added to the queue but instead of being processed, it will be sent to MQ with another name.
 
-```
+```javascript
 on
 	.eventReceived(eventName: string)
 	.withProperties(properties: array)
@@ -38,7 +38,7 @@ on
 
 Broadcasting means that the task will immediately be executed by ALL the listeners without using redis, the tasks will be "duplicated" across all listeners.
 
-```
+```javascript
 on
 	.broadcastReceived(eventName: string)
 	.do(callback: function)
@@ -48,7 +48,7 @@ on
 
 #### Processing
 
-```
+```javascript
 on
 	.eventReceived(eventName: string)
 	.withProperties(properties: array)
@@ -59,7 +59,7 @@ Any event received with the name registered on ```eventReceived``` will be added
 
 #### Dispatching
 
-```
+```javascript
 on
 	.eventReceived(eventName: string)
 	.withProperties(properties: array)
@@ -74,7 +74,7 @@ The pattern of listening to work queues is described at https://www.rabbitmq.com
 
 This are tasks that will be executed by a queue
 
-```
+```javascript
 on
 	.taskReceived(eventName: string)
 	.withProperties(properties: array)
@@ -87,7 +87,7 @@ This type of queues require the rabbitmq-delayed-message-exchange plugin
 
 The task will arrive at the queue with a set delay
 
-```
+```javascript
 on
 	.taskReceived(eventName: string, options: { isDelayed: boolean})
 	.withProperties(properties: array)
@@ -99,7 +99,7 @@ The pattern of listening to RPC requests described at https://www.rabbitmq.com/t
 
 On.js will order MQ to start listening for events registered and the callback registered will be executed by MQ and the results sent to the client who requested the data.
 
-```
+```javascript
 on
 	.eventReceived(eventName: string)
 	.withProperties(properties: array)
@@ -113,7 +113,7 @@ The response will be a JSON string so you will have to parse it. The type of res
 
 To initialize initialize a new instance and then call .init()
 
-```
+```javascript
 var options = {
 	redis: {
 		host: REDIS_HOST,
@@ -132,9 +132,30 @@ var on = new On(options)
 on.init()
 ```
 
+### reconnecting
+
+By default onjs will try to reconnect to rabbitmq if the connection is closed, including when using the MQ library to close a connection directly, if you need to tear down use onjs.tearDown() function, or you can disable this behavior by setting the config option `reconnectOnClose` to false
+
+```javascript
+const options = {
+	redis: {
+		host: REDIS_HOST,
+		port: REDIS_PORT
+	},
+	mq: {
+		url: RABBITMQ_URL,
+  	exchange_name: EXCHANGE_NAME
+	},
+	reconnectOnClose: false,
+}
+
+const on = new On(options)
+on.init()
+```
+
 ## Usage Example
 
-```
+```javascript
 var RabbitMQ = require('rabbitmq-lib')
 var On = require('./lib/on/on.js')
 
@@ -203,13 +224,13 @@ on.init()
 # Debugging and Logging
 Running 
 
-```
+```javascript
 on.debug()
 ```
 
 will enable all logging. If you only want to enable one particular event to have logging, you can do it as well by calling the .log method on a particular event:
 
-```
+```javascript
 on
 	.requestReceived('someRequest')
 	.withProperties(['userId'])
@@ -222,7 +243,7 @@ on
 # MQ Dependency
 The module has a dependency on a MQ class that handles the communication with MQ. In theory any kind of service with MQ should work as long as the communication with MQ is abstracted. The methods needed in the constructor are:
 
-```
+```javascript
 connect()
 disconnect()
 publish(eventName, data)

--- a/bin/prepare-test-environment
+++ b/bin/prepare-test-environment
@@ -9,7 +9,7 @@ REDIS_CONTAINER_PORT=19379
 
 function createRabbitContainer() {
 	id=$(docker run -d --name ${RABBIT_CONTAINER_NAME} \
-  -p 5672 \
+  -p 5672:5272 \
   -e RABBITMQ_ERLANG_COOKIE=SWQOKODSQALRPCLNMEQG \
   -e RABBITMQ_DEFAULT_USER=rabbitmq \
   -e RABBITMQ_DEFAULT_PASS=rabbitmq \

--- a/lib/on.js
+++ b/lib/on.js
@@ -561,9 +561,9 @@ class On extends EventEmitter {
     }
   }
 
-  _log (type, message) {
+  _log (type, message, metadata) {
     if (this.debugEnabled) {
-      return this.logger[type](message)
+      return this.logger[type](message, metadata)
     }
   }
 

--- a/lib/on.js
+++ b/lib/on.js
@@ -27,6 +27,7 @@ class On extends EventEmitter {
     this.currentEventTypeToRegister = null
     this.debugEnabled = false
     this.delayedExchangeNameIsEmpty = !options.mq.delayed_exchange_name && options.mq.delayed_exchange_name !== ''
+    this.reconnectOnClose = options.reconnectOnClose || true
 
     return this
   }
@@ -66,6 +67,10 @@ class On extends EventEmitter {
         this._log('info', 'Connected to MQ, initializing topics')
       })
 
+      this.mqInstance.on('connectionAttempt', async (attempt) => {
+        this._log('info', `MQ Connection attempt number ${attempt}`)
+      })
+
       this.mqInstance.on('reconnected', async (connection) => {
         this.setConnection(connection)
         this._log('info', 'ReConnected to MQ, initializing topics')
@@ -75,6 +80,13 @@ class On extends EventEmitter {
       this.mqInstance.on('error', (err) => {
         this._log('error', 'Connection error', err)
         throw err
+      })
+
+      this.mqInstance.on('close', async (err) => {
+        if (this.reconnectOnClose) {
+          this._log('error', 'MQ Connection closed attempting to reconnect', err)
+          await this.mqInstance.reconnect()
+        }
       })
 
       this._log('info', 'Connecting to RabbitMQ')
@@ -270,13 +282,13 @@ class On extends EventEmitter {
 
   async _initRPCRequests (requests) {
     try {
-      this._log('info', 'Listening for rpc requests', requests)
+      this._log('info', 'Listening for rpc requests')
 
       for (let request of requests) {
         let rpcInstance = new RPC()
         let channel = await this.mqInstance.createChannel()
         rpcInstance.setChannel(channel)
-        this._log('info', `Listening rpc request ${request.eventName}`, channel)
+        this._log('info', `Listening rpc request ${request.eventName}`)
         await rpcInstance.listen(request.eventName, request.actions[0])
       }
 

--- a/lib/on.js
+++ b/lib/on.js
@@ -27,7 +27,7 @@ class On extends EventEmitter {
     this.currentEventTypeToRegister = null
     this.debugEnabled = false
     this.delayedExchangeNameIsEmpty = !options.mq.delayed_exchange_name && options.mq.delayed_exchange_name !== ''
-    this.reconnectOnClose = options.reconnectOnClose || true
+    this.reconnectOnClose = options.reconnectOnClose ?? true
 
     return this
   }
@@ -157,6 +157,7 @@ class On extends EventEmitter {
   async tearDown () {
     try {
       this._log('info', 'Tearing down on.js. Closing connection and stopped listening events')
+      this.reconnectOnClose = false
       this.removeAllListeners()
       var connection = this.getConnection()
       return await connection.close()

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,20 +1,20 @@
 {
   "name": "onjs",
-  "version": "2.3.1",
+  "version": "2.4.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "onjs",
-      "version": "2.3.1",
+      "version": "2.4.0",
       "license": "MIT",
       "dependencies": {
-        "amqplib": "^0.10.3",
+        "amqplib": "^0.10.5",
         "bull": "^3.29.3",
         "mocha": "^5.2.0"
       },
       "devDependencies": {
-        "rabbitmq-lib": "^2.2.0",
+        "rabbitmq-lib": "^2.3.1",
         "should": "^13.1.3"
       },
       "engines": {
@@ -35,13 +35,12 @@
       }
     },
     "node_modules/amqplib": {
-      "version": "0.10.3",
-      "resolved": "https://registry.npmjs.org/amqplib/-/amqplib-0.10.3.tgz",
-      "integrity": "sha512-UHmuSa7n8vVW/a5HGh2nFPqAEr8+cD4dEZ6u9GjP91nHfr1a54RyAKyra7Sb5NH7NBKOUlyQSMXIp0qAixKexw==",
+      "version": "0.10.5",
+      "resolved": "https://registry.npmjs.org/amqplib/-/amqplib-0.10.5.tgz",
+      "integrity": "sha512-Dx5zmy0Ur+Q7LPPdhz+jx5IzmJBoHd15tOeAfQ8SuvEtyPJ20hBemhOBA4b1WeORCRa0ENM/kHCzmem1w/zHvQ==",
       "dependencies": {
         "@acuminous/bitsyntax": "^0.1.2",
         "buffer-more-ints": "~1.0.0",
-        "readable-stream": "1.x >=1.1.9",
         "url-parse": "~1.5.10"
       },
       "engines": {
@@ -162,11 +161,6 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="
-    },
-    "node_modules/core-util-is": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
-      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ=="
     },
     "node_modules/cron-parser": {
       "version": "2.18.0",
@@ -777,11 +771,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/isarray": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-      "integrity": "sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ=="
-    },
     "node_modules/lodash": {
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
@@ -1019,11 +1008,10 @@
       "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ=="
     },
     "node_modules/rabbitmq-lib": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/rabbitmq-lib/-/rabbitmq-lib-2.2.1.tgz",
-      "integrity": "sha512-ZWsmqObHRXqD2sAGdnfqPrgHFEmh5YbYE/yb/d1nhZY9PypokqToxj9sWGLiwILdAMTBKWvj3n0G2/g5JZ1XPQ==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/rabbitmq-lib/-/rabbitmq-lib-2.3.1.tgz",
+      "integrity": "sha512-VaUV2gKcUHMI+GPDTZ0dnbcAbiXNkMOZyREBpH7R74R3KBl+64+HgniV7/lEIPQvm+93/5yJu9Y/MYvvyZRTzQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "amqplib": "^0.10.3",
         "uuid": "^9.0.0"
@@ -1044,17 +1032,6 @@
       "license": "MIT",
       "bin": {
         "uuid": "dist/bin/uuid"
-      }
-    },
-    "node_modules/readable-stream": {
-      "version": "1.1.14",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
-      "integrity": "sha512-+MeVjFf4L44XUkhM1eYbD8fyEsxcV81pqMSR5gblfcLCHfZvbrqy4/qYHE+/R5HoBUT11WV5O08Cr1n3YXkWVQ==",
-      "dependencies": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.1",
-        "isarray": "0.0.1",
-        "string_decoder": "~0.10.x"
       }
     },
     "node_modules/redis-commands": {
@@ -1228,11 +1205,6 @@
       "resolved": "https://registry.npmjs.org/standard-as-callback/-/standard-as-callback-2.1.0.tgz",
       "integrity": "sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A=="
     },
-    "node_modules/string_decoder": {
-      "version": "0.10.31",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-      "integrity": "sha512-ev2QzSzWPYmy9GuqfIVildA4OdcGLeFZQrq5ys6RtiuF+RQQiZWr8TZNyAcuVXyQRYfEO+MsoB/1BuQVhOJuoQ=="
-    },
     "node_modules/string.prototype.trim": {
       "version": "1.2.7",
       "resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.2.7.tgz",
@@ -1404,13 +1376,12 @@
       }
     },
     "amqplib": {
-      "version": "0.10.3",
-      "resolved": "https://registry.npmjs.org/amqplib/-/amqplib-0.10.3.tgz",
-      "integrity": "sha512-UHmuSa7n8vVW/a5HGh2nFPqAEr8+cD4dEZ6u9GjP91nHfr1a54RyAKyra7Sb5NH7NBKOUlyQSMXIp0qAixKexw==",
+      "version": "0.10.5",
+      "resolved": "https://registry.npmjs.org/amqplib/-/amqplib-0.10.5.tgz",
+      "integrity": "sha512-Dx5zmy0Ur+Q7LPPdhz+jx5IzmJBoHd15tOeAfQ8SuvEtyPJ20hBemhOBA4b1WeORCRa0ENM/kHCzmem1w/zHvQ==",
       "requires": {
         "@acuminous/bitsyntax": "^0.1.2",
         "buffer-more-ints": "~1.0.0",
-        "readable-stream": "1.x >=1.1.9",
         "url-parse": "~1.5.10"
       }
     },
@@ -1504,11 +1475,6 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="
-    },
-    "core-util-is": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
-      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ=="
     },
     "cron-parser": {
       "version": "2.18.0",
@@ -1921,11 +1887,6 @@
         "call-bind": "^1.0.2"
       }
     },
-    "isarray": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-      "integrity": "sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ=="
-    },
     "lodash": {
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
@@ -2106,9 +2067,9 @@
       "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ=="
     },
     "rabbitmq-lib": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/rabbitmq-lib/-/rabbitmq-lib-2.2.1.tgz",
-      "integrity": "sha512-ZWsmqObHRXqD2sAGdnfqPrgHFEmh5YbYE/yb/d1nhZY9PypokqToxj9sWGLiwILdAMTBKWvj3n0G2/g5JZ1XPQ==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/rabbitmq-lib/-/rabbitmq-lib-2.3.1.tgz",
+      "integrity": "sha512-VaUV2gKcUHMI+GPDTZ0dnbcAbiXNkMOZyREBpH7R74R3KBl+64+HgniV7/lEIPQvm+93/5yJu9Y/MYvvyZRTzQ==",
       "dev": true,
       "requires": {
         "amqplib": "^0.10.3",
@@ -2121,17 +2082,6 @@
           "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
           "dev": true
         }
-      }
-    },
-    "readable-stream": {
-      "version": "1.1.14",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
-      "integrity": "sha512-+MeVjFf4L44XUkhM1eYbD8fyEsxcV81pqMSR5gblfcLCHfZvbrqy4/qYHE+/R5HoBUT11WV5O08Cr1n3YXkWVQ==",
-      "requires": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.1",
-        "isarray": "0.0.1",
-        "string_decoder": "~0.10.x"
       }
     },
     "redis-commands": {
@@ -2276,11 +2226,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/standard-as-callback/-/standard-as-callback-2.1.0.tgz",
       "integrity": "sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A=="
-    },
-    "string_decoder": {
-      "version": "0.10.31",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-      "integrity": "sha512-ev2QzSzWPYmy9GuqfIVildA4OdcGLeFZQrq5ys6RtiuF+RQQiZWr8TZNyAcuVXyQRYfEO+MsoB/1BuQVhOJuoQ=="
     },
     "string.prototype.trim": {
       "version": "1.2.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "onjs",
-  "version": "2.3.0",
+  "version": "2.4.0",
   "description": "On.js is an event library based on RabbitMQ that helps you control events on a microservices arquitecture",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -24,11 +24,11 @@
   },
   "engineStrict": true,
   "devDependencies": {
-    "rabbitmq-lib": "^2.2.0",
+    "rabbitmq-lib": "^2.3.1",
     "should": "^13.1.3"
   },
   "dependencies": {
-    "amqplib": "^0.10.3",
+    "amqplib": "^0.10.5",
     "bull": "^3.29.3",
     "mocha": "^5.2.0"
   }

--- a/tests/tests/queues.js
+++ b/tests/tests/queues.js
@@ -15,6 +15,8 @@ describe('Queue', function () {
     mq: {
       exchange_name: 'onjs_test',
       url: 'amqp://rabbitmq:rabbitmq@rabbitmq:5672/',
+      connectMaxAttempts: 1,
+      delayMS: 10,
     },
     redis: {
       port: REDIS_PORT,
@@ -29,7 +31,9 @@ describe('Queue', function () {
   on.debug()
 
   before(async function () {
+    console.log('1')
     await mq1.connect()
+    console.log('2')
     var channelConsumer = await mq1.createChannel()
     sender.setChannel(channelConsumer)
 

--- a/tests/tests/queues.js
+++ b/tests/tests/queues.js
@@ -21,7 +21,7 @@ describe('Queue', function () {
     redis: {
       port: REDIS_PORT,
       host: 'redis'
-    }
+    },
   }
 
   var mq1 = new MQ(config.mq)

--- a/tests/tests/queues.js
+++ b/tests/tests/queues.js
@@ -31,9 +31,7 @@ describe('Queue', function () {
   on.debug()
 
   before(async function () {
-    console.log('1')
     await mq1.connect()
-    console.log('2')
     var channelConsumer = await mq1.createChannel()
     sender.setChannel(channelConsumer)
 

--- a/tests/tests/rpcs.js
+++ b/tests/tests/rpcs.js
@@ -14,6 +14,8 @@ describe('RPC', function () {
     mq: {
       exchange_name: 'onjs_test',
       url: 'amqp://rabbitmq:rabbitmq@rabbitmq:5672/',
+      connectMaxAttempts: 1,
+      delayMS: 10,
     },
     redis: {
       port: REDIS_PORT,

--- a/tests/tests/rpcs.js
+++ b/tests/tests/rpcs.js
@@ -20,7 +20,8 @@ describe('RPC', function () {
     redis: {
       port: REDIS_PORT,
       host: 'redis'
-    }
+    },
+    reconnectOnClose: false,
   }
 
   var mq = new MQ(config.mq)

--- a/tests/tests/test.js
+++ b/tests/tests/test.js
@@ -24,7 +24,8 @@ describe('On.js', function () {
     redis: {
       port: REDIS_PORT,
       host: 'redis'
-    }
+    },
+    reconnectOnClose: false,
   }
 
   describe('Topics registration', function () {

--- a/tests/tests/test.js
+++ b/tests/tests/test.js
@@ -18,6 +18,8 @@ describe('On.js', function () {
     mq: {
       exchange_name: 'onjs_test',
       url: 'amqp://rabbitmq:rabbitmq@rabbitmq:5672/',
+      connectMaxAttempts: 1,
+      delayMS: 10,
     },
     redis: {
       port: REDIS_PORT,

--- a/tests/tests/topics.js
+++ b/tests/tests/topics.js
@@ -19,7 +19,8 @@ describe('Topics', function () {
     redis: {
       port: REDIS_PORT,
       host: 'redis'
-    }
+    },
+    reconnectOnClose: false,
   }
 
   var mq1 = new MQ(config.mq)

--- a/tests/tests/topics.js
+++ b/tests/tests/topics.js
@@ -13,6 +13,8 @@ describe('Topics', function () {
     mq: {
       exchange_name: 'onjs_test',
       url: 'amqp://rabbitmq:rabbitmq@rabbitmq:5672/',
+      connectMaxAttempts: 1,
+      delayMS: 10,
     },
     redis: {
       port: REDIS_PORT,


### PR DESCRIPTION
Adds a new feature that if enabled with the `reconnectOnClose` option (enabled by default) onjs will attempt to reconnect to MQ if the connection was closed, either by server restart or if the connection was reset from admin console.

This also fixes an issue with the logging function where it would not pass the metadata properly, also removes unnecessary metadata from a couple of logs since it adds a bunch of useless data.